### PR TITLE
Fixing order of directory creation for forget.py to prevent exiting

### DIFF
--- a/forget.py
+++ b/forget.py
@@ -54,25 +54,23 @@ def main(cfg):
     if cfg.model_path is None:
         cfg.model_path = model_cfg["ft_model_path"]
 
-    Path(cfg.save_dir).mkdir(parents=True, exist_ok=True)
-
+    print("######################")
+    print("Saving to: ", cfg.save_dir)
+    print("######################")
     # save cfg in cfg.save_dir
     if local_rank == 0:
+        if os.path.exists(cfg.save_dir):
+            print("Directory already exists")
+            if not cfg.overwrite_dir:
+                exit()
+
+        Path(cfg.save_dir).mkdir(parents=True, exist_ok=True)
+
         with open(f"{cfg.save_dir}/config.yaml", "w") as file:
             OmegaConf.save(cfg, file)
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     tokenizer.pad_token = tokenizer.eos_token
-
-    print("######################")
-    print("Saving to: ", cfg.save_dir)
-    print("######################")
-
-
-    if os.path.exists(cfg.save_dir):
-        print("Directory already exists")
-        if not cfg.overwrite_dir:
-            exit()
 
     max_length = 500
     if cfg.forget_loss == "dpo":


### PR DESCRIPTION
In forget.py script, the cfg.save_dir directory is created (line 57) then later, the script checks whether the directory exists and exits if it does (line 72). Because the directory is being created first, the script ALWAYS exits unless overwrite_dir is true, because the directory ALWAYS exists. This should not be the intended behavior.

In this PR, only the process on local_rank 0 checks if the save_dir exists, if it does, then it exits only if overwrite_dir is set to True. Otherwise, it creates the directory.