### PR TITLE
Finetuning with LORA causes DeepSpeed error

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -111,6 +111,7 @@ def main(cfg):
             task_type="CAUSAL_LM"
         )
         model = get_peft_model(model, config)
+        model.enable_input_require_grads()
     
 
     trainer = CustomTrainer(


### PR DESCRIPTION
When finetuning with LORA, the following error is produced: 
`RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn`

This is mentioned in this [issue](https://github.com/microsoft/DeepSpeed/issues/3339) in the DeepSpeed library.

Can be fixed with one line proposed in that issues comments.