### PR TITLE
Added support for LLaMa3

### DIFF
--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -21,6 +21,7 @@ phi:
   question_start_tag: "Question: "
   question_end_tag: "\n"
   answer_tag: "Answer: "
+  answer_end_tag: ""
   flash_attention2: "false"
   gradient_checkpointing: "false"
   ft_model_path: "locuslab/tofu_ft_phi-1.5"
@@ -29,6 +30,7 @@ stablelm:
   question_start_tag: "Question: "
   question_end_tag: "\n"
   answer_tag: "Answer: "
+  answer_end_tag: ""
   flash_attention2: "false"
   gradient_checkpointing: "false"
   ft_model_path: "paper_models/final_ft_noLORA_5_epochs_inst_lr1e-05_stablelm/checkpoint-625"
@@ -37,6 +39,7 @@ pythia-1.4:
   question_start_tag: "Question: "
   question_end_tag: "\n"
   answer_tag: "Answer: "
+  answer_end_tag: ""
   flash_attention2: "false"
   gradient_checkpointing: "false"
 

--- a/config/model_config.yaml
+++ b/config/model_config.yaml
@@ -3,9 +3,19 @@ llama2-7b:
   question_start_tag: "[INST] "
   question_end_tag: " [/INST]"
   answer_tag: ""
+  answer_end_tag: ""
   flash_attention2: "true"
   gradient_checkpointing: "true"
   ft_model_path: "locuslab/tofu_ft_llama2-7b" #this model will be used for unlearning by default
+llama3-8b:
+  hf_key: "meta-llama/Meta-Llama-3-8B-Instruct"
+  question_start_tag: "<|start_header_id|>user<|end_header_id|>\n\n"
+  question_end_tag: "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+  answer_tag: ""
+  answer_end_tag: "<|eot_id|>"
+  flash_attention2: "true"
+  gradient_checkpointing: "true"
+  ft_model_path: "locuslab/tofu_ft_llama3-8b"
 phi:
   hf_key: "microsoft/phi-1_5"
   question_start_tag: "Question: "

--- a/data_module.py
+++ b/data_module.py
@@ -9,6 +9,12 @@ def convert_raw_data_to_model_format(tokenizer, max_length,  question, answer, m
     question_start_token, question_end_token, answer_token = model_configs['question_start_tag'], model_configs['question_end_tag'], model_configs['answer_tag']
     new_question = question_start_token + question + question_end_token
     new_answer = answer_token + answer
+
+    # needed for LLaMa3 formatting, but making it an "if" to preserve backwards
+    # compatibility
+    if 'answer_end_tag' in model_configs.keys():
+        new_answer += model_configs['answer_end_tag']
+
     full_text = new_question + new_answer
     num_question_tokens = len(tokenizer.tokenize(new_question, add_special_tokens=True))
 

--- a/evaluate_util.py
+++ b/evaluate_util.py
@@ -303,13 +303,11 @@ def eval_accuracy(logits, labels):
 
 def run_generation(cfg, batch, model, tokenizer):
     input_ids = batch["input_ids"]
-    input_strings = tokenizer.batch_decode(input_ids, skip_special_tokens=True)
-    split_symbol = " [/INST]" if cfg.model_family == 'llama2-7b' else 'Answer: '
-    ground_truth = [s.split(split_symbol)[1] for s in input_strings]
-    input_strings = [s.split(split_symbol)[0] for s in input_strings]
-    #add ["/INST "] to the end of each string
-    if cfg.model_family == 'llama2-7b':
-        input_strings = [s + split_symbol for s in input_strings]
+    split_symbol = model_config['question_end_tag'] + model_config['answer_tag']
+    input_strings = tokenizer.batch_decode(input_ids)
+
+    ground_truth = [(model_config['answer_tag'] + s.split(split_symbol)[1]).replace(tokenizer.eos_token,'').replace(model_config['answer_end_tag'],'') for s in input_strings]
+    input_strings = [s.split(split_symbol)[0] + split_symbol for s in input_strings]
         
     #we only want to retain the input before the [/INST] token. split each string to only retain the content before the [/INST] token
     # ground_truth = [s.split("[/INST] ")[1] for s in input_strings]


### PR DESCRIPTION
Added Llama3 to the model config. Llama3-8b-Instruct was instruction tuned with several special tokens to denote system, user, and assistant chat roles, as well as messages. Thus, in order to support this, "answer_end_tag" needed to be added to the config as to the preprocessing in the data_module script. For more details on the formatting, refer to the [llama3 instruction tuning documentation](https://github.com/meta-llama/llama3/tree/main?tab=readme-ov-file#instruction-tuned-models).