### PR TITLE
docs: updated to CUDA 12.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The dataset is in QA format, making it ideal for use with popular chat models su
 ```
 conda create -n tofu python=3.10
 conda activate tofu
-conda install pytorch pytorch-cuda=11.8 -c pytorch -c nvidia
-conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit
+conda install pytorch pytorch-cuda=12.4 -c pytorch -c nvidia
+conda install -c "nvidia/label/cuda-12.4.0" cuda-toolkit
 pip install -r requirements.txt
 pip install flash-attn --no-build-isolation
 ```


### PR DESCRIPTION
This should fix #50

This excerpt below is taken directly from [flash-attention]( https://github.com/Dao-AILab/flash-attention)'s `README.md` at:

NVIDIA CUDA Support
Requirements:

CUDA 12.0 and above.
We recommend the [Pytorch](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) container from Nvidia, which has all the required tools to install FlashAttention.